### PR TITLE
Fix traceback when entity is not available

### DIFF
--- a/custom_components/google_geocode/sensor.py
+++ b/custom_components/google_geocode/sensor.py
@@ -184,7 +184,7 @@ class GoogleGeocode(Entity):
         if zone_check == self._zone_check_current and zone_check != 'not_home':    
             return
 
-        self._zone_check_current = self.hass.states.get(self._origin_entity_id).state
+        self._zone_check_current = zone_check
         lat = self._origin
         current = lat
         self._reset_attributes()


### PR DESCRIPTION
If an entity is based on a template then a trace back occurs upon starts of HASS due to it not being available. This PR fixes this issue.
Also cleaned up the logic a bit to determine when to check.