### PR TITLE
Fix geocode update cache and zone skip logic

### DIFF
--- a/custom_components/google_geocode/sensor.py
+++ b/custom_components/google_geocode/sensor.py
@@ -359,22 +359,31 @@ class GoogleGeocode(Entity):
         if self._origin is None:
             return
 
-        # If location is still the same then do not update
-        if self._current_location == self._origin:
-            return
-
         if hasattr(self, '_origin_entity_id') and self.hass.states.get(self._origin_entity_id) is not None:
             zone_check = self.hass.states.get(self._origin_entity_id).state
         else:
             zone_check = 'not_home'
 
-        # Do not update location if zone is still the same and defined (not not_home)
-        if zone_check == self._zone_check_current and zone_check != 'not_home':
+        # If the location is unchanged, skip unless we know the zone changed.
+        # A missing cached zone keeps the previous behavior for already cached
+        # locations while still allowing explicit zone changes to update.
+        if (
+                self._current_location == self._origin
+                and (
+                self._zone_check_current is None
+                or zone_check == self._zone_check_current
+                )
+        ):
             return
 
-        self._zone_check_current = zone_check
-        self._current_location = self._origin
-        self._reset_attributes()
+        # Do not update location if the entity is still in the same named zone,
+        # unless the user requested address display instead of zone display.
+        if (
+                zone_check == self._zone_check_current
+                and zone_check != 'not_home'
+                and self._display_zone != 'hide'
+        ):
+            return
 
         if self._api_key == DEFAULT_KEY:
             url = (
@@ -387,13 +396,22 @@ class GoogleGeocode(Entity):
                 f"?language={self._google_language}&region={self._google_region}&latlng={self._origin}&key={self._api_key}"
             )
         _LOGGER.debug("Google request sent: %s", url)
+
         try:
             response = requests.get(url, timeout=5)
             response.raise_for_status()
+            decoded = json.loads(response.text)
         except requests.exceptions.RequestException as err:
             _LOGGER.error("Failed to retrieve geocode from Google. Error: %s", err)
             return
-        decoded = json.loads(response.text)
+        except (json.JSONDecodeError, TypeError) as err:
+            _LOGGER.error("Failed to decode geocode response from Google. Error: %s", err)
+            return
+
+        self._zone_check_current = zone_check
+        self._current_location = self._origin
+        self._reset_attributes()
+
         street_number = ''
         street = 'Unnamed Road'
         alt_street = 'Unnamed Road'

--- a/custom_components/google_geocode/sensor.py
+++ b/custom_components/google_geocode/sensor.py
@@ -367,12 +367,9 @@ class GoogleGeocode(Entity):
         # If the location is unchanged, skip unless we know the zone changed.
         # A missing cached zone keeps the previous behavior for already cached
         # locations while still allowing explicit zone changes to update.
-        if (
-                self._current_location == self._origin
-                and (
+        if self._current_location == self._origin and (
                 self._zone_check_current is None
                 or zone_check == self._zone_check_current
-                )
         ):
             return
 

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -19,7 +19,8 @@ Covers all significant branches of update():
   - Misspelling / unknown token warnings for order= and options=
 """
 
-from unittest.mock import patch
+from unittest.mock import Mock, patch
+
 import requests
 
 # conftest.py inserts stubs onto sys.path before this module is imported.
@@ -1202,6 +1203,29 @@ class TestParseOptions:
         assert sensor._state == "Downing Street, London"
         assert sensor._current_location == "51.5,-0.12"
         assert sensor._zone_check_current == "not_home"
+
+    def test_update_handles_invalid_json(self, make_sensor, hass):
+        """Invalid JSON responses should not crash or cache the location."""
+        hass.set_state(
+            "device_tracker.phone",
+            "not_home",
+            {"latitude": 51.5, "longitude": -0.12},
+        )
+        sensor = make_sensor(origin="device_tracker.phone")
+
+        bad_response = Mock()
+        bad_response.raise_for_status.return_value = None
+        bad_response.text = "THIS IS NOT JSON"
+
+        with patch(
+                "custom_components.google_geocode.sensor.requests.get",
+                return_value=bad_response,
+        ):
+            sensor.update()
+
+        assert sensor._state == STATE_AWAITING_UPDATE
+        assert sensor._current_location == "0,0"
+        assert sensor._zone_check_current is None
 
     def test_display_zone_hide_updates_address_in_same_named_zone(self, make_sensor, hass):
         """When zones are hidden, changed coordinates in the same zone need geocoding."""

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -20,6 +20,7 @@ Covers all significant branches of update():
 """
 
 from unittest.mock import patch
+import requests
 
 # conftest.py inserts stubs onto sys.path before this module is imported.
 from custom_components.google_geocode.sensor import (
@@ -1156,3 +1157,73 @@ class TestParseOptions:
 
         assert sensor._state == "Downing Street, London"
         assert not sensor._state.startswith(",")
+
+    def test_update_when_zone_changes_with_same_location(self, make_sensor, hass):
+        """A zone state change must update even if coordinates are unchanged."""
+        hass.set_state("device_tracker.phone", "home", {"latitude": 51.5, "longitude": -0.12})
+        sensor = make_sensor(origin="device_tracker.phone", display_zone="display")
+
+        with patch("custom_components.google_geocode.sensor.requests.get",
+                   return_value=mock_api_response(FULL_API_RESPONSE)):
+            sensor.update()
+
+        assert sensor._state == "Home"
+        assert sensor._current_location == "51.5,-0.12"
+        assert sensor._zone_check_current == "home"
+
+        hass.set_state("device_tracker.phone", "not_home", {"latitude": 51.5, "longitude": -0.12})
+
+        with patch("custom_components.google_geocode.sensor.requests.get",
+                   return_value=mock_api_response(FULL_API_RESPONSE)) as mock_get:
+            sensor.update()
+
+        mock_get.assert_called_once()
+        assert sensor._state == "Downing Street, London"
+        assert sensor._zone_check_current == "not_home"
+
+    def test_failed_request_does_not_cache_location(self, make_sensor, hass):
+        """A failed request should be retried on the next update for the same location."""
+        hass.set_state("device_tracker.phone", "not_home", {"latitude": 51.5, "longitude": -0.12})
+        sensor = make_sensor(origin="device_tracker.phone")
+
+        with patch("custom_components.google_geocode.sensor.requests.get",
+                   side_effect=requests.exceptions.Timeout):
+            sensor.update()
+
+        assert sensor._state == STATE_AWAITING_UPDATE
+        assert sensor._current_location == "0,0"
+        assert sensor._zone_check_current is None
+
+        with patch("custom_components.google_geocode.sensor.requests.get",
+                   return_value=mock_api_response(FULL_API_RESPONSE)) as mock_get:
+            sensor.update()
+
+        mock_get.assert_called_once()
+        assert sensor._state == "Downing Street, London"
+        assert sensor._current_location == "51.5,-0.12"
+        assert sensor._zone_check_current == "not_home"
+
+    def test_display_zone_hide_updates_address_in_same_named_zone(self, make_sensor, hass):
+        """When zones are hidden, changed coordinates in the same zone need geocoding."""
+        hass.set_state("device_tracker.phone", "home", {"latitude": 51.5, "longitude": -0.12})
+        sensor = make_sensor(
+            origin="device_tracker.phone",
+            display_zone="hide",
+            options="street, city",
+        )
+
+        with patch("custom_components.google_geocode.sensor.requests.get",
+                   return_value=mock_api_response(FULL_API_RESPONSE)):
+            sensor.update()
+
+        assert sensor._state == "Downing Street, London"
+        assert sensor._zone_check_current == "home"
+
+        hass.set_state("device_tracker.phone", "home", {"latitude": 52.0, "longitude": -0.13})
+
+        with patch("custom_components.google_geocode.sensor.requests.get",
+                   return_value=mock_api_response(FULL_API_RESPONSE)) as mock_get:
+            sensor.update()
+
+        mock_get.assert_called_once()
+        assert sensor._current_location == "52.0,-0.13"


### PR DESCRIPTION
## Summary

Fixes bad Google Geocode sensor updates caused by aggressive skip/cache logic.

## Changes

- Check the tracked entity zone before skipping unchanged coordinates.
- Avoid caching a location as processed when the Google request fails.
- Retry geocoding after request/JSON failures.
- Allow `display_zone: hide` to update the address when coordinates change inside the same named zone.
- Add regression tests for the fixed cases.